### PR TITLE
EE-6629: Fix jenkins pipeline used to runtimeProjectsBuild which does…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 Map pipelineParams = [ : ]
 
-runtimeExtensionsBuild(pipelineParams)
+runtimeProjectsBuild(pipelineParams)


### PR DESCRIPTION
…n't have the corrupted snapshot validation.